### PR TITLE
Refactor I2C bus initialization into shared class

### DIFF
--- a/Polaris-Synth-2.0/lib/ExternalADC/ExternalADC.cpp
+++ b/Polaris-Synth-2.0/lib/ExternalADC/ExternalADC.cpp
@@ -1,1 +1,65 @@
-#include <ExternalADC.h>
+#include "ExternalADC.h"
+
+// ADS1015 register addresses
+static constexpr uint8_t ADS1015_REG_CONVERSION = 0x00;
+static constexpr uint8_t ADS1015_REG_CONFIG     = 0x01;
+
+// Bits for configuration register
+static constexpr uint16_t ADS1015_CFG_OS_SINGLE    = 0x8000;
+static constexpr uint16_t ADS1015_CFG_MUX_OFFSET   = 12;      // MUX bits shift
+static constexpr uint16_t ADS1015_CFG_PGA_2_048V   = 0x0200;  // +/-2.048V range
+static constexpr uint16_t ADS1015_CFG_MODE_SINGLE  = 0x0100;  // single-shot mode
+static constexpr uint16_t ADS1015_CFG_DR_1600SPS   = 0x0080;  // 1600 samples per second
+static constexpr uint16_t ADS1015_CFG_CQUE_NONE    = 0x0003;  // disable comparator
+
+ExternalADC::ExternalADC(I2CBus &bus, uint8_t i2c_addr)
+    : _bus(bus), _i2c_addr(i2c_addr)
+{
+}
+
+esp_err_t ExternalADC::writeReg(uint8_t reg, uint16_t value)
+{
+    uint8_t buf[3];
+    buf[0] = reg;
+    buf[1] = static_cast<uint8_t>(value >> 8);
+    buf[2] = static_cast<uint8_t>(value & 0xFF);
+    return i2c_master_write_to_device(_bus.port(), _i2c_addr, buf, sizeof(buf), pdMS_TO_TICKS(1000));
+}
+
+esp_err_t ExternalADC::readReg(uint8_t reg, uint16_t *value)
+{
+    uint8_t data[2] = {0, 0};
+    esp_err_t err = i2c_master_write_read_device(_bus.port(), _i2c_addr, &reg, 1, data, 2, pdMS_TO_TICKS(1000));
+    if (err == ESP_OK && value) {
+        *value = (static_cast<uint16_t>(data[0]) << 8) | data[1];
+    }
+    return err;
+}
+
+int16_t ExternalADC::readChannel(uint8_t channel)
+{
+    if (channel > 3) {
+        return 0;
+    }
+
+    // Build configuration word
+    uint16_t config = ADS1015_CFG_OS_SINGLE |
+                      (static_cast<uint16_t>(channel) << ADS1015_CFG_MUX_OFFSET) |
+                      ADS1015_CFG_PGA_2_048V |
+                      ADS1015_CFG_MODE_SINGLE |
+                      ADS1015_CFG_DR_1600SPS |
+                      ADS1015_CFG_CQUE_NONE;
+
+    // Start single conversion
+    writeReg(ADS1015_REG_CONFIG, config);
+
+    // Wait for conversion to complete (~1ms for 1600SPS)
+    vTaskDelay(pdMS_TO_TICKS(2));
+
+    uint16_t raw = 0;
+    readReg(ADS1015_REG_CONVERSION, &raw);
+
+    // The ADS1015 returns 12-bit results in the upper bits of the 16-bit register
+    return static_cast<int16_t>(raw) >> 4;
+}
+

--- a/Polaris-Synth-2.0/lib/ExternalADC/ExternalADC.h
+++ b/Polaris-Synth-2.0/lib/ExternalADC/ExternalADC.h
@@ -1,3 +1,32 @@
+#pragma once
+
+// Simple driver for the ADS1015 external ADC.
+// Assumes the I2C bus has been initialised elsewhere and
+// provides helpers to read/write 16‑bit registers on the device.
+
+#include <cstdint>
+#include "driver/i2c.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "I2CBus.h"
+
 class ExternalADC {
-    
+public:
+    // Construct with an initialised I2C bus and device address.
+    ExternalADC(I2CBus &bus, uint8_t i2c_addr);
+
+    // Write a 16‑bit value to an ADS1015 register.
+    esp_err_t writeReg(uint8_t reg, uint16_t value);
+
+    // Read a 16‑bit value from an ADS1015 register.
+    esp_err_t readReg(uint8_t reg, uint16_t *value);
+
+    // Convenience method to read a single ended conversion from
+    // the given channel [0‑3]. Returns raw 12‑bit signed value.
+    int16_t readChannel(uint8_t channel);
+
+private:
+    I2CBus &_bus;
+    uint8_t _i2c_addr;
 };
+

--- a/Polaris-Synth-2.0/lib/I2CBus/I2CBus.cpp
+++ b/Polaris-Synth-2.0/lib/I2CBus/I2CBus.cpp
@@ -1,0 +1,33 @@
+#include "I2CBus.h"
+
+I2CBus::I2CBus(i2c_port_t port)
+    : _port(port), _initialised(false)
+{
+}
+
+esp_err_t I2CBus::init(gpio_num_t sda_pin, gpio_num_t scl_pin, uint32_t clk_speed)
+{
+    if (_initialised) {
+        return ESP_OK;
+    }
+
+    i2c_config_t conf = {};
+    conf.mode = I2C_MODE_MASTER;
+    conf.sda_io_num = sda_pin;
+    conf.scl_io_num = scl_pin;
+    conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
+    conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
+    conf.master.clk_speed = clk_speed;
+
+    esp_err_t err = i2c_param_config(_port, &conf);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = i2c_driver_install(_port, conf.mode, 0, 0, 0);
+    if (err == ESP_OK) {
+        _initialised = true;
+    }
+    return err;
+}
+

--- a/Polaris-Synth-2.0/lib/I2CBus/I2CBus.h
+++ b/Polaris-Synth-2.0/lib/I2CBus/I2CBus.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "driver/i2c.h"
+#include <cstdint>
+
+// Helper class that initialises and represents an I2C bus.
+// Multiple devices can share the same bus instance.
+class I2CBus {
+public:
+    explicit I2CBus(i2c_port_t port);
+
+    // Configure and install the I2C driver if not already initialised.
+    esp_err_t init(gpio_num_t sda_pin, gpio_num_t scl_pin, uint32_t clk_speed = 400000);
+
+    // Return the underlying I2C port number.
+    i2c_port_t port() const { return _port; }
+
+private:
+    i2c_port_t _port;
+    bool _initialised;
+};
+

--- a/Polaris-Synth-2.0/lib/IOExpander/IOExpander.cpp
+++ b/Polaris-Synth-2.0/lib/IOExpander/IOExpander.cpp
@@ -1,8 +1,8 @@
 #include <IOExpander.h>
 
-// Constructor: i2c_port, device i2c address
-MCP23017::MCP23017(i2c_port_t i2c_port, uint8_t i2c_addr)
-    : _i2c_port(i2c_port), _i2c_addr(i2c_addr)
+// Constructor: I2C bus, device i2c address
+MCP23017::MCP23017(I2CBus &bus, uint8_t i2c_addr)
+    : _bus(bus), _i2c_addr(i2c_addr)
 {
     // 1. Set all pins on both banks as inputs.
     writeReg(0x00, 0xFF); // IODIRA all inputs
@@ -35,7 +35,7 @@ void MCP23017::writeReg(uint8_t reg, uint8_t data)
     i2c_master_write_byte(cmd, reg, true);
     i2c_master_write_byte(cmd, data, true);
     i2c_master_stop(cmd);
-    i2c_master_cmd_begin(_i2c_port, cmd, pdMS_TO_TICKS(1000));
+    i2c_master_cmd_begin(_bus.port(), cmd, pdMS_TO_TICKS(1000));
     i2c_cmd_link_delete(cmd);
 }
 // Read from register 'reg' into data pointer
@@ -49,7 +49,7 @@ void MCP23017::readReg(uint8_t reg, uint8_t* data)
     i2c_master_write_byte(cmd, (_i2c_addr << 1) | I2C_MASTER_READ, true);
     i2c_master_read_byte(cmd, data, I2C_MASTER_NACK);
     i2c_master_stop(cmd);
-    i2c_master_cmd_begin(_i2c_port, cmd, pdMS_TO_TICKS(1000));
+    i2c_master_cmd_begin(_bus.port(), cmd, pdMS_TO_TICKS(1000));
     i2c_cmd_link_delete(cmd);
 }
 

--- a/Polaris-Synth-2.0/lib/IOExpander/IOExpander.h
+++ b/Polaris-Synth-2.0/lib/IOExpander/IOExpander.h
@@ -7,12 +7,13 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include <cstdint>
+#include "I2CBus.h"
 
 class MCP23017
 {
 public:
-    // Constructor: i2c_port, device i2c address
-    MCP23017(i2c_port_t i2c_port, uint8_t i2c_addr);
+    // Constructor: I2C bus and device i2c address
+    MCP23017(I2CBus &bus, uint8_t i2c_addr);
 
     // Interrupt handler to be attached to the ESP32 interrupt pin.
     // This clears the interrupt state by reading the INTCAP registers.
@@ -23,7 +24,7 @@ public:
     uint8_t readGPIOB();
 
 private:
-    i2c_port_t _i2c_port;
+    I2CBus &_bus;
     uint8_t _i2c_addr;
 
     // Write a single byte 'data' to register 'reg'


### PR DESCRIPTION
## Summary
- introduce reusable `I2CBus` class to configure the ESP32's I2C master once
- update `ExternalADC` to use shared `I2CBus` for ADS1015 register access
- modify `MCP23017` IO expander to operate via the shared bus as well

## Testing
- `pio run -e esp32dev` *(fails: HTTPClientError while installing espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b14e55c14c8332a9240411f18b3a75