### PR TITLE
Add ESP32 MAX3421E USB MIDI host

### DIFF
--- a/Polaris-Synth-2.0/lib/MidiUSB/MidiUSB.cpp
+++ b/Polaris-Synth-2.0/lib/MidiUSB/MidiUSB.cpp
@@ -1,1 +1,53 @@
-#include <MidiUSB.h>
+#include "MidiUSB.h"
+
+#include <SPI.h>
+
+MidiUSB *MidiUSB::s_instance = nullptr;
+
+MidiUSB::MidiUSB(int interruptPin, MidiHandler &parser)
+    : _intPin(interruptPin),
+      _usb(),
+      _midi(&_usb),
+      _parser(parser),
+      _irqFlag(false) {
+    s_instance = this;
+}
+
+bool MidiUSB::begin() {
+    // Initialise SPI with default pins (SCK=18, MISO=19, MOSI=23, SS=5)
+    SPI.begin();
+
+    pinMode(_intPin, INPUT_PULLUP);
+    attachInterrupt(digitalPinToInterrupt(_intPin), MidiUSB::usbInterrupt, FALLING);
+
+    if (_usb.Init() == -1) {
+        return false; // initialisation failed
+    }
+
+    delay(200); // give devices time to enumerate
+    return true;
+}
+
+void MidiUSB::task() {
+    _usb.Task();
+
+    if (!_irqFlag) {
+        return; // nothing to process
+    }
+
+    _irqFlag = false;
+
+    uint8_t buf[3];
+    uint8_t size;
+    while ((size = _midi.RecvData(buf)) > 0) {
+        _parser.parse(buf, size);
+    }
+}
+
+void IRAM_ATTR MidiUSB::usbInterrupt() {
+    if (s_instance) {
+        s_instance->_usb.ISR();
+        s_instance->_irqFlag = true;
+    }
+}
+

--- a/Polaris-Synth-2.0/lib/MidiUSB/MidiUSB.h
+++ b/Polaris-Synth-2.0/lib/MidiUSB/MidiUSB.h
@@ -1,4 +1,47 @@
-class MidiUSB {
-    
+// MidiUSB.h - interface for USB MIDI host using MAX3421E on ESP32
+#pragma once
 
+#include <Arduino.h>
+#include <USB.h>
+#include <usbh_midi.h>
+
+#include "MidiHandler.h"
+
+/**
+ * MidiUSB sets up the MAX3421E USB host controller and forwards any MIDI
+ * messages from attached USB MIDI devices to a MidiHandler instance. The class
+ * itself performs no interpretation of the MIDI data.
+ */
+class MidiUSB {
+public:
+    /**
+     * Create a new MidiUSB interface.
+     * @param interruptPin GPIO pin used for the MAX3421E INT line.
+     * @param parser       MidiHandler instance that will parse received data.
+     */
+    explicit MidiUSB(int interruptPin, MidiHandler &parser);
+
+    /**
+     * Initialise the MAX3421E and USB host stack.
+     * @return true on success, false otherwise.
+     */
+    bool begin();
+
+    /**
+     * Process pending USB transactions and pass any MIDI messages to the
+     * parser. Should be called frequently from the main loop.
+     */
+    void task();
+
+private:
+    static void IRAM_ATTR usbInterrupt();
+
+    static MidiUSB *s_instance;
+
+    int _intPin;
+    USB _usb;
+    USBH_MIDI _midi;
+    MidiHandler &_parser;
+    volatile bool _irqFlag;
 };
+


### PR DESCRIPTION
## Summary
- implement MidiUSB class for ESP32 to read USB MIDI from MAX3421E host
- setup SPI and interrupt handling
- forward received messages to MidiHandler for parsing

## Testing
- `pio test` *(fails: HTTPClientError installing platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b15912e7108332bbaacb5450bfe342