### PR TITLE
Show cutoff frequency and Q on the Bode plot screen

### DIFF
--- a/Polaris-Synth-2.0/lib/DisplayManager/DisplayManager.cpp
+++ b/Polaris-Synth-2.0/lib/DisplayManager/DisplayManager.cpp
@@ -382,6 +382,28 @@ void DisplayManager::drawBodeScreen() {
         }
         prevY = y;
     }
+
+    // Overlay the current cutoff frequency and resonance Q so the numbers are
+    // readable alongside the curve. F is the 2^32-scaled phase increment
+    // (F = 2^32 * fc / fs), so fc = F * fs / 2^32 with fs = 44100Hz.
+    float fcHz = (float)F * (44100.0f / 4294967296.0f);
+    char fcStr[10];
+    if (fcHz >= 1000.0f)
+        snprintf(fcStr, sizeof(fcStr), "%.2fkHz", fcHz / 1000.0f);
+    else
+        snprintf(fcStr, sizeof(fcStr), "%dHz", (int)(fcHz + 0.5f));
+
+    char buf[24];
+    snprintf(buf, sizeof(buf), "Fc:%s Q:%.1f", fcStr, q);
+
+    // Clear a box behind the text (leaving the x=0 axis intact) so it stays
+    // legible where it crosses the plotted curve.
+    int w = oled->getStrWidth(buf);
+    oled->setDrawColor(0);
+    oled->drawBox(1, 0, w + 2, 7);
+    oled->setDrawColor(1);
+    oled->setCursor(2, 6);
+    oled->print(buf);
 }
 
 // Raw ADC diagnostic view: unfiltered readings for all 26 knob channels in a


### PR DESCRIPTION
Overlay the filter's current cutoff frequency (derived from the
2^32-scaled phase increment) and resonance Q as text on the Bode
visualize screen so the numbers are readable alongside the curve.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0115sF5r8oKSyW6FcqE8DjFT